### PR TITLE
Refactor: Slack client instance using DI

### DIFF
--- a/inc/Abstracts/Service.php
+++ b/inc/Abstracts/Service.php
@@ -12,6 +12,7 @@ namespace PingMeOnSlack\Abstracts;
 
 use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Interfaces\Kernel;
+use PingMeOnSlack\Interfaces\Dispatcher;
 
 abstract class Service implements Kernel {
 	/**
@@ -20,27 +21,6 @@ abstract class Service implements Kernel {
 	 * @var static[]
 	 */
 	public static $services = [];
-
-	/**
-	 * Slack Client.
-	 *
-	 * This client is responsible for sending messages
-	 * to the Slack API.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @var \PingMeOnSlack\Client
-	 */
-	public Client $client;
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 1.0.0
-	 */
-	public function __construct() {
-		$this->client = new Client();
-	}
 
 	/**
 	 * Get Instance.
@@ -74,6 +54,29 @@ abstract class Service implements Kernel {
 	 */
 	public function get_date(): string {
 		return gmdate( 'H:i:s, d-m-Y' );
+	}
+
+	/**
+	 * Get Dispatcher.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @param Dispatcher $dispatcher
+	 * @return void
+	 */
+	protected function get_dispatcher( Dispatcher $dispatcher ): Dispatcher {
+		return $dispatcher;
+	}
+
+	/**
+	 * Get Client.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @return Dispatcher
+	 */
+	public function get_client(): Dispatcher {
+		return $this->get_dispatcher( new Client() );
 	}
 
 	/**

--- a/inc/Core/Client.php
+++ b/inc/Core/Client.php
@@ -15,6 +15,25 @@ use PingMeOnSlack\Interfaces\Dispatcher;
 
 class Client implements Dispatcher {
 	/**
+	 * Get Slack Client.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @return SlackClient
+	 */
+	protected function get_slack_client(): SlackClient {
+		$settings = get_option( 'ping_me_on_slack', [] );
+
+		return new SlackClient(
+			$settings['webhook'] ?? '',
+			[
+				'channel'  => $settings['channel'] ?? '',
+				'username' => $settings['username'] ?? '',
+			]
+		);
+	}
+
+	/**
 	 * Ping Slack.
 	 *
 	 * This method handles the Remote POST calls
@@ -26,18 +45,8 @@ class Client implements Dispatcher {
 	 * @return void
 	 */
 	public function ping( $message ): void {
-		$settings = get_option( 'ping_me_on_slack', [] );
-
-		$slack = new SlackClient(
-			$settings['webhook'] ?? '',
-			[
-				'channel'  => $settings['channel'] ?? '',
-				'username' => $settings['username'] ?? '',
-			]
-		);
-
 		try {
-			$slack->send( $message );
+			$this->get_slack_client()->send( $message );
 		} catch ( \Exception $e ) {
 			error_log(
 				sprintf(

--- a/inc/Core/Client.php
+++ b/inc/Core/Client.php
@@ -11,60 +11,9 @@
 namespace PingMeOnSlack\Core;
 
 use Maknz\Slack\Client as SlackClient;
+use PingMeOnSlack\Interfaces\Dispatcher;
 
-class Client {
-	/**
-	 * Slack Client.
-	 *
-	 * Responsible for sending JSON payload to Slack's
-	 * services endpoint on behalf of plugin.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @var SlackClient
-	 */
-	public SlackClient $slack;
-
-	/**
-	 * Slack Args.
-	 *
-	 * Specify JSON payload here to be sent when
-	 * making API calls.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @var mixed[]
-	 */
-	public array $args;
-
-	/**
-	 * Plugin Settings.
-	 *
-	 * Grab plugin options from Options table specific
-	 * to this plugin.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @var mixed[]
-	 */
-	public array $settings;
-
-	/**
-	 * Set up.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	public function __construct() {
-		$this->settings = get_option( 'ping_me_on_slack', [] );
-
-		$this->args = [
-			'channel'  => $this->settings['channel'] ?? '',
-			'username' => $this->settings['username'] ?? '',
-		];
-	}
-
+class Client implements Dispatcher {
 	/**
 	 * Ping Slack.
 	 *
@@ -77,18 +26,23 @@ class Client {
 	 * @return void
 	 */
 	public function ping( $message ): void {
-		$this->slack = new SlackClient(
-			$this->settings['webhook'] ?? '',
-			$this->args
+		$settings = get_option( 'ping_me_on_slack', [] );
+
+		$slack = new SlackClient(
+			$settings['webhook'] ?? '',
+			[
+				'channel'  => $settings['channel'] ?? '',
+				'username' => $settings['username'] ?? '',
+			]
 		);
 
 		try {
-			$this->slack->send( $message );
-		} catch ( \RuntimeException $e ) {
+			$slack->send( $message );
+		} catch ( \Exception $e ) {
 			error_log(
 				sprintf(
 					'Fatal Error: Something went wrong... %s',
-					wp_json_encode( $this->args ) . ' ' . $e->getMessage()
+					$e->getMessage()
 				)
 			);
 

--- a/inc/Core/Client.php
+++ b/inc/Core/Client.php
@@ -63,10 +63,10 @@ class Client implements Dispatcher {
 			 *
 			 * @since 1.0.0
 			 *
-			 * @param \RuntimeException $e Exception object.
+			 * @param string $e Exception error message.
 			 * @return void
 			 */
-			do_action( 'ping_me_on_slack_on_ping_error', $e );
+			do_action( 'ping_me_on_slack_on_ping_error', $e->getMessage() );
 		}
 	}
 }

--- a/inc/Interfaces/Dispatcher.php
+++ b/inc/Interfaces/Dispatcher.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Dispatch Interface.
+ *
+ * Define the base methods that must be shared
+ * across client classes.
+ *
+ * @package PingMeOnSlack
+ */
+
+namespace PingMeOnSlack\Interfaces;
+
+interface Dispatcher {
+	/**
+	 * Send Message.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @return void
+	 */
+	public function ping( $message ): void;
+}

--- a/inc/Services/Access.php
+++ b/inc/Services/Access.php
@@ -58,7 +58,7 @@ class Access extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( 'ping_me_on_slack_login_client', $client = $this->client );
+		$client = apply_filters( 'ping_me_on_slack_login_client', $client = $this->get_client() );
 
 		$access_login = pmos_get_settings( 'access_login' );
 
@@ -91,7 +91,7 @@ class Access extends Service implements Kernel {
 		 */
 		$message = (string) apply_filters( 'ping_me_on_slack_login_message', $message, $user );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 
 	/**
@@ -123,7 +123,7 @@ class Access extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( 'ping_me_on_slack_logout_client', $client = $this->client );
+		$client = apply_filters( 'ping_me_on_slack_logout_client', $client = $this->get_client() );
 
 		$user = get_user_by( 'id', $user_id );
 
@@ -158,6 +158,6 @@ class Access extends Service implements Kernel {
 		 */
 		$message = (string) apply_filters( 'ping_me_on_slack_logout_message', $message, $user );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 }

--- a/inc/Services/Comment.php
+++ b/inc/Services/Comment.php
@@ -76,6 +76,9 @@ class Comment extends Service implements Kernel {
 		// Get Event Type.
 		$this->event = $new_status;
 
+		// Set Message.
+		$message = '';
+
 		switch ( $new_status ) {
 			case 'approved':
 				$comment_approve = pmos_get_settings( 'comment_approve' );
@@ -105,9 +108,9 @@ class Comment extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( 'ping_me_on_slack_comment_client', $client = $this->client );
+		$client = apply_filters( 'ping_me_on_slack_comment_client', $client = $this->get_client() );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 
 	/**

--- a/inc/Services/Comment.php
+++ b/inc/Services/Comment.php
@@ -16,6 +16,24 @@ use PingMeOnSlack\Interfaces\Kernel;
 
 class Comment extends Service implements Kernel {
 	/**
+	 * WP Comment.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @var \WP_Comment
+	 */
+	public \WP_Comment $comment;
+
+	/**
+	 * Comment Event.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @var string
+	 */
+	public string $event;
+
+	/**
 	 * Bind to WP.
 	 *
 	 * @since 1.0.0

--- a/inc/Services/Post.php
+++ b/inc/Services/Post.php
@@ -76,6 +76,9 @@ class Post extends Service implements Kernel {
 		// Get Event Type.
 		$this->event = $new_status;
 
+		// Set Message.
+		$message = '';
+
 		switch ( $new_status ) {
 			case 'draft':
 				$post_draft = pmos_get_settings( 'post_draft' );
@@ -113,9 +116,9 @@ class Post extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( "ping_me_on_slack_{$this->post->post_type}_client", $client = $this->client );
+		$client = apply_filters( "ping_me_on_slack_{$this->post->post_type}_client", $client = $this->get_client() );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 
 	/**

--- a/inc/Services/Post.php
+++ b/inc/Services/Post.php
@@ -16,6 +16,24 @@ use PingMeOnSlack\Interfaces\Kernel;
 
 class Post extends Service implements Kernel {
 	/**
+	 * WP Post.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @var \WP_Post
+	 */
+	public \WP_Post $post;
+
+	/**
+	 * Post Event.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @var string
+	 */
+	public string $event;
+
+	/**
 	 * Bind to WP.
 	 *
 	 * @since 1.0.0

--- a/inc/Services/Theme.php
+++ b/inc/Services/Theme.php
@@ -15,6 +15,15 @@ use PingMeOnSlack\Interfaces\Kernel;
 
 class Theme extends Service implements Kernel {
 	/**
+	 * WP Theme.
+	 *
+	 * @since 1.1.3
+	 *
+	 * @var \WP_Theme
+	 */
+	public \WP_Theme $theme;
+
+	/**
 	 * Bind to WP.
 	 *
 	 * @since 1.0.0

--- a/inc/Services/Theme.php
+++ b/inc/Services/Theme.php
@@ -70,9 +70,9 @@ class Theme extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( 'ping_me_on_slack_theme_client', $client = $this->client );
+		$client = apply_filters( 'ping_me_on_slack_theme_client', $client = $this->get_client() );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 
 	/**

--- a/inc/Services/User.php
+++ b/inc/Services/User.php
@@ -58,7 +58,7 @@ class User extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( 'ping_me_on_slack_user_creation_client', $client = $this->client );
+		$client = apply_filters( 'ping_me_on_slack_user_creation_client', $client = $this->get_client() );
 
 		$user_create = pmos_get_settings( 'user_create' );
 
@@ -91,7 +91,7 @@ class User extends Service implements Kernel {
 		 */
 		$message = (string) apply_filters( 'ping_me_on_slack_user_creation_message', $message, $user_id );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 
 	/**
@@ -124,7 +124,7 @@ class User extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( 'ping_me_on_slack_user_modification_client', $client = $this->client );
+		$client = apply_filters( 'ping_me_on_slack_user_modification_client', $client = $this->get_client() );
 
 		$user_modify = pmos_get_settings( 'user_modify' );
 
@@ -157,7 +157,7 @@ class User extends Service implements Kernel {
 		 */
 		$message = (string) apply_filters( 'ping_me_on_slack_user_modification_message', $message, $user_id );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 
 	/*
@@ -191,7 +191,7 @@ class User extends Service implements Kernel {
 		 * @param Client $client Client Instance.
 		 * @return Client
 		 */
-		$this->client = apply_filters( 'ping_me_on_slack_user_deletion_client', $client = $this->client );
+		$client = apply_filters( 'ping_me_on_slack_user_deletion_client', $client = $this->get_client() );
 
 		$user_delete = pmos_get_settings( 'user_delete' );
 
@@ -224,6 +224,6 @@ class User extends Service implements Kernel {
 		 */
 		$message = (string) apply_filters( 'ping_me_on_slack_user_deletion_message', $message, $user_id );
 
-		$this->client->ping( $message );
+		$client->ping( $message );
 	}
 }

--- a/tests/Abstracts/ServiceTest.php
+++ b/tests/Abstracts/ServiceTest.php
@@ -6,29 +6,20 @@ use Mockery;
 use WP_Mock\Tools\TestCase;
 use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Abstracts\Service;
+use PingMeOnSlack\Interfaces\Dispatcher;
 
 /**
- * @covers \PingMeOnSlack\Abstracts\Service::__construct
  * @covers \PingMeOnSlack\Abstracts\Service::get_instance
  * @covers \PingMeOnSlack\Abstracts\Service::get_date
+ * @covers \PingMeOnSlack\Abstracts\Service::get_dispatcher
+ * @covers \PingMeOnSlack\Abstracts\Service::get_client
  * @covers \PingMeOnSlack\Abstracts\Service::register
- * @covers \PingMeOnSlack\Core\Client::__construct
  */
 class ServiceTest extends TestCase {
 	public Service $service;
 
 	public function setUp(): void {
 		\WP_Mock::setUp();
-
-		\WP_Mock::userFunction( 'get_option' )
-			->once()
-			->with( 'ping_me_on_slack', [] )
-			->andReturn(
-				[
-					'channel'  => '#general',
-					'username' => 'Bryan',
-				]
-			);
 
 		$this->service = new ConcreteService();
 	}
@@ -38,16 +29,6 @@ class ServiceTest extends TestCase {
 	}
 
 	public function test_get_instance_returns_singleton() {
-		\WP_Mock::userFunction( 'get_option' )
-			->once()
-			->with( 'ping_me_on_slack', [] )
-			->andReturn(
-				[
-					'channel'  => '#general',
-					'username' => 'Bryan',
-				]
-			);
-
 		$expected_1 = ConcreteService::get_instance();
 		$expected_2 = ConcreteService::get_instance();
 
@@ -69,8 +50,22 @@ class ServiceTest extends TestCase {
 		$this->assertConditionsMet();
 	}
 
-	public function test_client_returns_client_instance() {
-		$this->assertInstanceOf( Client::class, $this->service->client );
+	public function test_get_client_returns_client_instance() {
+		$service = Mockery::mock( ConcreteService::class )->makePartial();
+		$service->shouldAllowMockingProtectedMethods();
+
+		$this->assertInstanceOf( Client::class, $service->get_client() );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_dispatcher_returns_dispatcher() {
+		$service = Mockery::mock( ConcreteService::class )->makePartial();
+		$service->shouldAllowMockingProtectedMethods();
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->assertInstanceOf( Dispatcher::class, $service->get_dispatcher( $client ) );
 		$this->assertConditionsMet();
 	}
 }

--- a/tests/Core/ClientTest.php
+++ b/tests/Core/ClientTest.php
@@ -8,14 +8,25 @@ use PingMeOnSlack\Core\Client;
 use Maknz\Slack\Client as SlackClient;
 
 /**
- * @covers \PingMeOnSlack\Core\Client::__construct
  * @covers \PingMeOnSlack\Core\Client::ping
+ * @covers \PingMeOnSlack\Core\Client::get_slack_client
  */
 class ClientTest extends TestCase {
 	public Client $client;
 
 	public function setUp(): void {
 		\WP_Mock::setUp();
+
+		$this->client = new Client();
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_get_slack_client() {
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
 
 		\WP_Mock::userFunction( 'get_option' )
 			->once()
@@ -28,23 +39,48 @@ class ClientTest extends TestCase {
 				]
 			);
 
-		$this->client = new Client();
-	}
-
-	public function tearDown(): void {
-		\WP_Mock::tearDown();
-	}
-
-	public function test_args_set_up_default() {
-		$this->assertSame( '#general', $this->client->args['channel'] );
-		$this->assertSame( 'Bryan', $this->client->args['username'] );
+		$this->assertInstanceOf( SlackClient::class, $client->get_slack_client() );
 		$this->assertConditionsMet();
 	}
 
 	public function test_ping() {
-		$this->client->ping( 'Ping: A post was just published!' );
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
 
-		$this->assertInstanceOf( \Maknz\Slack\Client::class, $this->client->slack );
+		$slack_client = Mockery::mock( SlackClient::class )->makePartial();
+		$slack_client->shouldAllowMockingProtectedMethods();
+
+		$client->shouldReceive( 'get_slack_client' )
+			->andReturn( $slack_client );
+
+		$slack_client->shouldReceive( 'send' )
+			->andReturn( null );
+
+		$client->ping( 'Ping: A post was just published!' );
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_ping_throws_exception() {
+		$exception = new \Exception( 'No Text Found.' );
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$slack_client = Mockery::mock( SlackClient::class )->makePartial();
+		$slack_client->shouldAllowMockingProtectedMethods();
+
+		$client->shouldReceive( 'get_slack_client' )
+			->andReturn( $slack_client );
+
+		$slack_client->shouldReceive( 'send' )
+			->with( 'Ping: A post was just published!' )
+			->andThrow( $exception );
+
+		\WP_Mock::expectAction( 'ping_me_on_slack_on_ping_error', 'No Text Found.' );
+
+		$client->ping( 'Ping: A post was just published!' );
+
 		$this->assertConditionsMet();
 	}
 }

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -19,6 +19,14 @@ use PingMeOnSlack\Core\Container;
 /**
  * @covers \PingMeOnSlack\Core\Container::__construct
  * @covers \PingMeOnSlack\Core\Container::register
+ * @covers \PingMeOnSlack\Abstracts\Service::get_instance
+ * @covers \PingMeOnSlack\Services\Access::register
+ * @covers \PingMeOnSlack\Services\Admin::register
+ * @covers \PingMeOnSlack\Services\Boot::register
+ * @covers \PingMeOnSlack\Services\Comment::register
+ * @covers \PingMeOnSlack\Services\Post::register
+ * @covers \PingMeOnSlack\Services\Theme::register
+ * @covers \PingMeOnSlack\Services\User::register
  */
 class ContainerTest extends TestCase {
 	public Container $container;
@@ -41,6 +49,132 @@ class ContainerTest extends TestCase {
 		$this->assertTrue( in_array( Post::class, Container::$services, true ) );
 		$this->assertTrue( in_array( Theme::class, Container::$services, true ) );
 		$this->assertTrue( in_array( User::class, Container::$services, true ) );
+		$this->assertConditionsMet();
+	}
+
+	public function test_register() {
+		$container = new Container();
+
+		/**
+		 * We create instances of services so we can
+		 * have a populated version of the Service abstraction's instances.
+		 */
+		foreach ( Container::$services as $service ) {
+			$service::get_instance();
+		}
+
+		\WP_Mock::expectActionAdded(
+			'init',
+			[
+				Service::$services[ Boot::class ],
+				'ping_me_on_slack_translation',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'wp_login',
+			[
+				Service::$services[ Access::class ],
+				'ping_on_user_login',
+			],
+			10,
+			2
+		);
+
+		\WP_Mock::expectActionAdded(
+			'wp_logout',
+			[
+				Service::$services[ Access::class ],
+				'ping_on_user_logout',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				Service::$services[ Admin::class ],
+				'register_options_init',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'admin_menu',
+			[
+				Service::$services[ Admin::class ],
+				'register_options_menu',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'admin_enqueue_scripts',
+			[
+				Service::$services[ Admin::class ],
+				'register_options_styles',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'transition_comment_status',
+			[
+				Service::$services[ Comment::class ],
+				'ping_on_comment_status_change',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'transition_post_status',
+			[
+				Service::$services[ Post::class ],
+				'ping_on_post_status_change',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'switch_theme',
+			[
+				Service::$services[ Theme::class ],
+				'ping_on_theme_change',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'user_register',
+			[
+				Service::$services[ User::class ],
+				'ping_on_user_creation',
+			],
+			10,
+			2
+		);
+
+		\WP_Mock::expectActionAdded(
+			'wp_update_user',
+			[
+				Service::$services[ User::class ],
+				'ping_on_user_modification',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'deleted_user',
+			[
+				Service::$services[ User::class ],
+				'ping_on_user_deletion',
+			],
+			10,
+			3
+		);
+
+		$container->register();
+
 		$this->assertConditionsMet();
 	}
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -19,9 +19,7 @@ use PingMeOnSlack\Services\Comment;
 /**
  * @covers \PingMeOnSlack\Plugin::get_instance
  * @covers \PingMeOnSlack\Plugin::run
- * @covers \PingMeOnSlack\Abstracts\Service::__construct
  * @covers \PingMeOnSlack\Abstracts\Service::get_instance
- * @covers \PingMeOnSlack\Core\Client::__construct
  * @covers \PingMeOnSlack\Core\Container::__construct
  * @covers \PingMeOnSlack\Core\Container::register
  * @covers \PingMeOnSlack\Services\Access::register
@@ -52,17 +50,6 @@ class PluginTest extends TestCase {
 	}
 
 	public function test_plugin_runs_singleton_instance() {
-		\WP_Mock::userFunction( 'get_option' )
-			->times( 7 )
-			->with( 'ping_me_on_slack', [] )
-			->andReturn(
-				[
-					'webhook'  => 'https://hooks.services.slack.com',
-					'channel'  => '#general',
-					'username' => 'Bryan',
-				]
-			);
-
 		$this->services = [
 			'Access'  => Access::get_instance(),
 			'Admin'   => Admin::get_instance(),

--- a/tests/Services/AccessTest.php
+++ b/tests/Services/AccessTest.php
@@ -8,7 +8,6 @@ use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Services\Access;
 
 /**
- * @covers \PingMeOnSlack\Services\Access::__construct
  * @covers \PingMeOnSlack\Services\Access::register
  * @covers \PingMeOnSlack\Services\Access::ping_on_user_login
  * @covers \PingMeOnSlack\Services\Access::ping_on_user_logout
@@ -48,7 +47,13 @@ class AccessTest extends TestCase {
 		$user     = Mockery::mock( \WP_User::class )->makePartial();
 		$user->ID = 1;
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_login_client', $this->access->client );
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->access->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
+		\WP_Mock::expectFilter( 'ping_me_on_slack_login_client', $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -92,7 +97,7 @@ class AccessTest extends TestCase {
 			->with()
 			->andReturn( '08:57:13, 01-07-2024' );
 
-		$this->access->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( $message );
 
@@ -107,7 +112,13 @@ class AccessTest extends TestCase {
 		$user     = Mockery::mock( \WP_User::class )->makePartial();
 		$user->ID = 1;
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_login_client', $this->access->client );
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->access->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
+		\WP_Mock::expectFilter( 'ping_me_on_slack_login_client', $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -151,7 +162,7 @@ class AccessTest extends TestCase {
 			->with()
 			->andReturn( '08:57:13, 01-07-2024' );
 
-		$this->access->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( $message );
 
@@ -185,6 +196,12 @@ class AccessTest extends TestCase {
 		$user             = Mockery::mock( \WP_User::class )->makePartial();
 		$user->user_login = 'john@doe.com';
 
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->access->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
 			->andReturn(
@@ -199,7 +216,7 @@ class AccessTest extends TestCase {
 			->with( 'id', 1 )
 			->andReturn( $user );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_logout_client', $this->access->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_logout_client', $client );
 
 		\WP_Mock::userFunction(
 			'esc_html__',
@@ -234,7 +251,7 @@ class AccessTest extends TestCase {
 			->with()
 			->andReturn( '08:57:13, 01-07-2024' );
 
-		$this->access->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( $message );
 
@@ -248,6 +265,12 @@ class AccessTest extends TestCase {
 
 		$user             = Mockery::mock( \WP_User::class )->makePartial();
 		$user->user_login = 'john@doe.com';
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->access->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -263,7 +286,7 @@ class AccessTest extends TestCase {
 			->with( 'id', 1 )
 			->andReturn( $user );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_logout_client', $this->access->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_logout_client', $client );
 
 		\WP_Mock::userFunction(
 			'esc_html__',
@@ -298,7 +321,7 @@ class AccessTest extends TestCase {
 			->with()
 			->andReturn( '08:57:13, 01-07-2024' );
 
-		$this->access->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( $message );
 

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -7,8 +7,6 @@ use WP_Mock\Tools\TestCase;
 use PingMeOnSlack\Services\Admin;
 
 /**
- * @covers \PingMeOnSlack\Core\Client::__construct
- * @covers \PingMeOnSlack\Services\Admin::__construct
  * @covers \PingMeOnSlack\Services\Admin::register
  * @covers \PingMeOnSlack\Services\Admin::register_options_menu
  * @covers \PingMeOnSlack\Services\Admin::register_options_init

--- a/tests/Services/BootTest.php
+++ b/tests/Services/BootTest.php
@@ -8,7 +8,6 @@ use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Services\Boot;
 
 /**
- * @covers \PingMeOnSlack\Services\Boot::__construct
  * @covers \PingMeOnSlack\Services\Boot::register
  * @covers \PingMeOnSlack\Services\Boot::ping_me_on_slack_translation
  */

--- a/tests/Services/CommentTest.php
+++ b/tests/Services/CommentTest.php
@@ -8,7 +8,6 @@ use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Services\Comment;
 
 /**
- * @covers \PingMeOnSlack\Services\Comment::__construct
  * @covers \PingMeOnSlack\Services\Comment::register
  * @covers \PingMeOnSlack\Services\Comment::ping_on_comment_status_change
  * @covers \PingMeOnSlack\Services\Comment::get_message
@@ -79,6 +78,12 @@ class CommentTest extends TestCase {
 		$comment = Mockery::mock( \WP_Comment::class )->makePartial();
 		$comment->shouldAllowMockingProtectedMethods();
 
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->comment->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
 			->andReturn(
@@ -105,11 +110,11 @@ class CommentTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'A Comment was just approved!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $client );
 
 		$this->comment->ping_on_comment_status_change( 'approved', 'draft', $comment );
 
@@ -119,6 +124,12 @@ class CommentTest extends TestCase {
 	public function test_ping_on_comment_status_change_passes_on_approved_with_custom_option() {
 		$comment = Mockery::mock( \WP_Comment::class )->makePartial();
 		$comment->shouldAllowMockingProtectedMethods();
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->comment->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -146,11 +157,11 @@ class CommentTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'Custom Message: Your comment is approved!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $client );
 
 		$this->comment->ping_on_comment_status_change( 'approved', 'draft', $comment );
 
@@ -160,6 +171,12 @@ class CommentTest extends TestCase {
 	public function test_ping_on_comment_status_change_passes_on_trash() {
 		$comment = Mockery::mock( \WP_Comment::class )->makePartial();
 		$comment->shouldAllowMockingProtectedMethods();
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->comment->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -187,11 +204,11 @@ class CommentTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'A Comment was just trashed!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $client );
 
 		$this->comment->ping_on_comment_status_change( 'trash', 'approved', $comment );
 
@@ -201,6 +218,12 @@ class CommentTest extends TestCase {
 	public function test_ping_on_comment_status_change_passes_on_trash_with_custom_option() {
 		$comment = Mockery::mock( \WP_Comment::class )->makePartial();
 		$comment->shouldAllowMockingProtectedMethods();
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->comment->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -228,11 +251,11 @@ class CommentTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'Custom Message: Your comment is trashed!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_comment_client', $client );
 
 		$this->comment->ping_on_comment_status_change( 'trash', 'approved', $comment );
 

--- a/tests/Services/PostTest.php
+++ b/tests/Services/PostTest.php
@@ -8,7 +8,6 @@ use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Services\Post;
 
 /**
- * @covers \PingMeOnSlack\Services\Post::__construct
  * @covers \PingMeOnSlack\Services\Post::register
  * @covers \PingMeOnSlack\Services\Post::ping_on_post_status_change
  * @covers \PingMeOnSlack\Services\Post::get_message
@@ -97,6 +96,12 @@ class PostTest extends TestCase {
 		$post->shouldAllowMockingProtectedMethods();
 		$post->post_type = 'post';
 
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->post->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
 		$this->post->post = $post;
 
 		\WP_Mock::userFunction( 'get_option' )
@@ -125,11 +130,11 @@ class PostTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'A Post was just published!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $client );
 
 		$this->post->ping_on_post_status_change( 'publish', 'draft', $post );
 
@@ -140,6 +145,12 @@ class PostTest extends TestCase {
 		$post = Mockery::mock( \WP_Post::class )->makePartial();
 		$post->shouldAllowMockingProtectedMethods();
 		$post->post_type = 'post';
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->post->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		$this->post->post = $post;
 
@@ -169,11 +180,11 @@ class PostTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'Custom Message: Your post is now published!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $client );
 
 		$this->post->ping_on_post_status_change( 'publish', 'draft', $post );
 
@@ -184,6 +195,12 @@ class PostTest extends TestCase {
 		$post = Mockery::mock( \WP_Post::class )->makePartial();
 		$post->shouldAllowMockingProtectedMethods();
 		$post->post_type = 'post';
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->post->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		$this->post->post = $post;
 
@@ -213,11 +230,11 @@ class PostTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'A Post draft was just created!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $client );
 
 		$this->post->ping_on_post_status_change( 'draft', 'auto-draft', $post );
 
@@ -228,6 +245,12 @@ class PostTest extends TestCase {
 		$post = Mockery::mock( \WP_Post::class )->makePartial();
 		$post->shouldAllowMockingProtectedMethods();
 		$post->post_type = 'post';
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->post->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		$this->post->post = $post;
 
@@ -257,11 +280,11 @@ class PostTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'Custom Message: Your post is now drafted!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $client );
 
 		$this->post->ping_on_post_status_change( 'draft', 'auto-draft', $post );
 
@@ -272,6 +295,12 @@ class PostTest extends TestCase {
 		$post = Mockery::mock( \WP_Post::class )->makePartial();
 		$post->shouldAllowMockingProtectedMethods();
 		$post->post_type = 'post';
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->post->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		$this->post->post = $post;
 
@@ -301,11 +330,11 @@ class PostTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'A Post was just trashed!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $client );
 
 		$this->post->ping_on_post_status_change( 'trash', 'publish', $post );
 
@@ -316,6 +345,12 @@ class PostTest extends TestCase {
 		$post = Mockery::mock( \WP_Post::class )->makePartial();
 		$post->shouldAllowMockingProtectedMethods();
 		$post->post_type = 'post';
+
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->post->shouldReceive( 'get_client' )
+			->andReturn( $client );
 
 		$this->post->post = $post;
 
@@ -345,11 +380,11 @@ class PostTest extends TestCase {
 				}
 			);
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'Custom Message: Your post is now trashed!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_post_client', $client );
 
 		$this->post->ping_on_post_status_change( 'trash', 'publish', $post );
 

--- a/tests/Services/ThemeTest.php
+++ b/tests/Services/ThemeTest.php
@@ -8,7 +8,6 @@ use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Services\Theme;
 
 /**
- * @covers \PingMeOnSlack\Services\Theme::__construct
  * @covers \PingMeOnSlack\Services\Theme::register
  * @covers \PingMeOnSlack\Services\Theme::ping_on_theme_change
  * @covers \PingMeOnSlack\Services\Theme::get_message
@@ -56,6 +55,12 @@ class ThemeTest extends TestCase {
 		$theme2 = Mockery::mock( \WP_Theme::class )->makePartial();
 		$theme2->shouldAllowMockingProtectedMethods();
 
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->theme->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
@@ -71,11 +76,11 @@ class ThemeTest extends TestCase {
 			->with( 'A Theme was just switched!' )
 			->andReturn( 'A Theme was just switched!' );
 
-		$this->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( 'A Theme was just switched!' );
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_theme_client', $this->client );
+		\WP_Mock::expectFilter( 'ping_me_on_slack_theme_client', $client );
 
 		$this->theme->ping_on_theme_change( 'Divi', $theme1, $theme2 );
 

--- a/tests/Services/UserTest.php
+++ b/tests/Services/UserTest.php
@@ -8,7 +8,6 @@ use PingMeOnSlack\Core\Client;
 use PingMeOnSlack\Services\User;
 
 /**
- * @covers \PingMeOnSlack\Services\User::__construct
  * @covers \PingMeOnSlack\Services\User::register
  * @covers \PingMeOnSlack\Services\User::ping_on_user_creation
  * @covers \PingMeOnSlack\Services\User::ping_on_user_modification
@@ -71,7 +70,13 @@ class UserTest extends TestCase {
 		$user->ID         = 1;
 		$user->user_login = 'john@doe.com';
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_user_creation_client', $this->user->client );
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->user->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
+		\WP_Mock::expectFilter( 'ping_me_on_slack_user_creation_client', $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -127,7 +132,7 @@ class UserTest extends TestCase {
 			->with()
 			->andReturn( '08:57:13, 01-07-2024' );
 
-		$this->user->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( $message );
 
@@ -163,7 +168,13 @@ class UserTest extends TestCase {
 		$user->ID         = 1;
 		$user->user_login = 'john@doe.com';
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_user_modification_client', $this->user->client );
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->user->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
+		\WP_Mock::expectFilter( 'ping_me_on_slack_user_modification_client', $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -219,7 +230,7 @@ class UserTest extends TestCase {
 			->with()
 			->andReturn( '08:57:13, 01-07-2024' );
 
-		$this->user->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( $message );
 
@@ -255,7 +266,13 @@ class UserTest extends TestCase {
 		$user->ID         = 1;
 		$user->user_login = 'john@doe.com';
 
-		\WP_Mock::expectFilter( 'ping_me_on_slack_user_deletion_client', $this->user->client );
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$this->user->shouldReceive( 'get_client' )
+			->andReturn( $client );
+
+		\WP_Mock::expectFilter( 'ping_me_on_slack_user_deletion_client', $client );
 
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'ping_me_on_slack', [] )
@@ -306,7 +323,7 @@ class UserTest extends TestCase {
 			->with()
 			->andReturn( '08:57:13, 01-07-2024' );
 
-		$this->user->client->shouldReceive( 'ping' )
+		$client->shouldReceive( 'ping' )
 			->once()
 			->with( $message );
 


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ping-me-on-slack/issues/1).

## Description / Background Context

This PR introduces a refactor that ensures the Slack client is interchangeable with a new Client via DI.

## Testing Instructions

1. Pull PR to local.
2. All features should work correctly as before.
3. Implement a **new Client** instance and substitute `new Client()` for this, it should work as expected.