### PR TITLE
Feat: Add custom filter for dispatcher `ping_me_on_slack_dispatcher`

### DIFF
--- a/inc/Abstracts/Service.php
+++ b/inc/Abstracts/Service.php
@@ -65,7 +65,16 @@ abstract class Service implements Kernel {
 	 * @return void
 	 */
 	protected function get_dispatcher( Dispatcher $dispatcher ): Dispatcher {
-		return $dispatcher;
+		/**
+		 * Filter Dispatcher.
+		 *
+		 * Customise the Dispatch client here, you can
+		 * make this extensible.
+		 *
+		 * @since 1.1.4
+		 * @return Dispatcher Client.
+		 */
+		return apply_filters( 'ping_me_on_slack_dispatcher', $dispatcher );
 	}
 
 	/**

--- a/inc/Abstracts/Service.php
+++ b/inc/Abstracts/Service.php
@@ -68,11 +68,13 @@ abstract class Service implements Kernel {
 		/**
 		 * Filter Dispatcher.
 		 *
-		 * Customise the Dispatch client here, you can
+		 * Customise the global Slack client here, you can
 		 * make this extensible.
 		 *
 		 * @since 1.1.4
-		 * @return Dispatcher Client.
+		 *
+		 * @param Dispatcher $dispatcher Slack client.
+		 * @return Dispatcher.
 		 */
 		return apply_filters( 'ping_me_on_slack_dispatcher', $dispatcher );
 	}

--- a/tests/Abstracts/ServiceTest.php
+++ b/tests/Abstracts/ServiceTest.php
@@ -54,6 +54,12 @@ class ServiceTest extends TestCase {
 		$service = Mockery::mock( ConcreteService::class )->makePartial();
 		$service->shouldAllowMockingProtectedMethods();
 
+		$client = Mockery::mock( Client::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$service->shouldReceive( 'get_dispatcher' )
+			->andReturn( $client );
+
 		$this->assertInstanceOf( Client::class, $service->get_client() );
 		$this->assertConditionsMet();
 	}
@@ -64,6 +70,8 @@ class ServiceTest extends TestCase {
 
 		$client = Mockery::mock( Client::class )->makePartial();
 		$client->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::expectFilter( 'ping_me_on_slack_dispatcher', $client );
 
 		$this->assertInstanceOf( Dispatcher::class, $service->get_dispatcher( $client ) );
 		$this->assertConditionsMet();


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ping-me-on-slack/issues/4).

## Description / Background Context

This PR introduces a filter `ping_me_on_slack_dispatcher` that ensures users can set a **global** Slack client.

## Testing Instructions

1. Pull PR to local.
2. Add a new Slack client using a custom filter like so:

```php
use MySlackClient;

add_filter( 'ping_me_on_slack_dispatcher', function( $client ) {
    new MySlackClient() );
}
```

3. All tests should pass as before when you run: `composer run test`