### PR TITLE
Feat: Add password control to form class

### DIFF
--- a/inc/Admin/Form.php
+++ b/inc/Admin/Form.php
@@ -231,6 +231,10 @@ class Form {
 				$control = $this->get_text_control( $arg, $name );
 				break;
 
+			case 'password':
+				$control = $this->get_password_control( $arg, $name );
+				break;
+
 			case 'select':
 				$control = $this->get_select_control( $arg, $name );
 				break;
@@ -259,6 +263,28 @@ class Form {
 	protected function get_text_control( $arg, $name ): string {
 		return sprintf(
 			'<input type="text" placeholder="%1$s" value="%2$s" name="%3$s"/>',
+			$arg['placeholder'] ?? '',
+			$this->get_setting( $name ),
+			$name,
+		);
+	}
+
+	/**
+	 * Get Password Control.
+	 *
+	 * This method is responsible for getting
+	 * Password controls.
+	 *
+	 * @since 1.1.4
+	 *
+	 * @param mixed[] $arg  Password args.
+	 * @param string  $name Control name.
+	 *
+	 * @return string
+	 */
+	protected function get_password_control( $arg, $name ): string {
+		return sprintf(
+			'<input type="password" placeholder="%1$s" value="%2$s" name="%3$s"/>',
 			$arg['placeholder'] ?? '',
 			$this->get_setting( $name ),
 			$name,

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -140,7 +140,7 @@ class Options {
 						'summary'     => esc_html__( 'e.g. #general', 'ping-me-on-slack' ),
 					],
 					'webhook'  => [
-						'control'     => esc_attr( 'text' ),
+						'control'     => esc_attr( 'password' ),
 						'placeholder' => esc_attr( '' ),
 						'label'       => esc_html__( 'Slack Webhook', 'ping-me-on-slack' ),
 						'summary'     => esc_html__( 'e.g. https://hooks.slack.com/services/xxxxxx', 'ping-me-on-slack' ),

--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,8 @@
 
 /* FORM CONTROLS */
 
-.badasswp-form-group-block input[type=text] {
+.badasswp-form-group-block input[type=text],
+.badasswp-form-group-block input[type=password] {
 	width: 100%;
 	box-sizing: border-box;
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -17,6 +17,7 @@ use PingMeOnSlack\Admin\Form;
  * @covers \PingMeOnSlack\Admin\Form::get_setting
  * @covers \PingMeOnSlack\Admin\Form::get_form_control
  * @covers \PingMeOnSlack\Admin\Form::get_text_control
+ * @covers \PingMeOnSlack\Admin\Form::get_password_control
  * @covers \PingMeOnSlack\Admin\Form::get_checkbox_control
  * @covers \PingMeOnSlack\Admin\Form::get_select_control
  * @covers \PingMeOnSlack\Admin\Form::get_form_submit
@@ -44,9 +45,9 @@ class FormTest extends TestCase {
 					'option'  => 'plugin_option',
 				],
 				'fields' => [
-					'form_group_1',
-					'form_group_2',
-					'form_group_3',
+					[ 'form_group_1' ],
+					[ 'form_group_2' ],
+					[ 'form_group_3' ],
 				],
 				'submit' => [
 					'heading' => 'Plugin Title',
@@ -142,9 +143,9 @@ class FormTest extends TestCase {
 		\WP_Mock::expectFilter(
 			'ping_me_on_slack_form_fields',
 			[
-				'form_group_1',
-				'form_group_2',
-				'form_group_3',
+				[ 'form_group_1' ],
+				[ 'form_group_2' ],
+				[ 'form_group_3' ],
 			]
 		);
 
@@ -154,7 +155,7 @@ class FormTest extends TestCase {
 				function ( $arg ) {
 					return sprintf(
 						'<section>%s</section>',
-						$arg
+						json_encode( $arg )
 					);
 				}
 			);
@@ -162,7 +163,7 @@ class FormTest extends TestCase {
 		$form_main = $this->form->get_form_main();
 
 		$this->assertSame(
-			'<section>form_group_1</section><section>form_group_2</section><section>form_group_3</section>',
+			'<section>["form_group_1"]</section><section>["form_group_2"]</section><section>["form_group_3"]</section>',
 			$form_main
 		);
 	}
@@ -263,6 +264,33 @@ class FormTest extends TestCase {
 		$this->assertSame( 'Text Control', $control );
 	}
 
+	public function test_get_form_control_returns_password_control() {
+		$this->form->shouldReceive( 'get_password_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'password',
+					'placeholder' => 'Password Placeholder',
+					'label'       => 'Password Label',
+					'summary'     => 'Password Summary',
+				],
+				'password_name'
+			)
+			->andReturn( 'Password Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'password',
+				'placeholder' => 'Password Placeholder',
+				'label'       => 'Password Label',
+				'summary'     => 'Password Summary',
+			],
+			'password_name'
+		);
+
+		$this->assertSame( 'Password Control', $control );
+	}
+
 	public function test_get_form_control_returns_select_control() {
 		$this->form->shouldReceive( 'get_select_control' )
 			->once()
@@ -333,6 +361,26 @@ class FormTest extends TestCase {
 
 		$this->assertSame(
 			'<input type="text" placeholder="Text Placeholder" value="Text Name" name="text_name"/>',
+			$control
+		);
+	}
+
+	public function test_get_password_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 1 )->with( 'text_name' )->andReturn( 'Text Name' );
+
+		$control = $this->form->get_password_control(
+			[
+				'control'     => 'text',
+				'placeholder' => 'Text Placeholder',
+				'label'       => 'Text Label',
+				'summary'     => 'Text Summary',
+			],
+			'text_name'
+		);
+
+		$this->assertSame(
+			'<input type="password" placeholder="Text Placeholder" value="Text Name" name="text_name"/>',
 			$control
 		);
 	}

--- a/tests/Admin/OptionsTest.php
+++ b/tests/Admin/OptionsTest.php
@@ -123,7 +123,7 @@ class OptionsTest extends TestCase {
 							'summary'     => 'e.g. #general',
 						],
 						'webhook'  => [
-							'control'     => 'text',
+							'control'     => 'password',
 							'placeholder' => '',
 							'label'       => 'Slack Webhook',
 							'summary'     => 'e.g. https://hooks.slack.com/services/xxxxxx',


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ping-me-on-slack/issues/7).

## Description / Background Context

This PR introduces a new `password` control into our **Form** class and associated unit tests to go with.

## Testing Instructions

1. Pull PR to local.
2. View plugin options page **Ping Me On Slack**.
3. **Slack Webhook** field should now look like so:

<img width="442" alt="password" src="https://github.com/user-attachments/assets/f4f69763-548c-4ff5-aa9d-6cb703050ac7" />