### PR TITLE
Refactor: Use Helper function `pmos_get_settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Use helper function `pmos_get_settings`.
+
 ## 1.1.4
 * Custom filter `ping_me_on_slack_dispatcher` for global Slack client.
 * Feat: New Password control in Form options.

--- a/inc/Core/Client.php
+++ b/inc/Core/Client.php
@@ -22,13 +22,11 @@ class Client implements Dispatcher {
 	 * @return SlackClient
 	 */
 	protected function get_slack_client(): SlackClient {
-		$settings = get_option( 'ping_me_on_slack', [] );
-
 		return new SlackClient(
-			$settings['webhook'] ?? '',
+			pmos_get_settings( 'webhook' ),
 			[
-				'channel'  => $settings['channel'] ?? '',
-				'username' => $settings['username'] ?? '',
+				'channel'  => pmos_get_settings( 'channel' ),
+				'username' => pmos_get_settings( 'username' ),
 			]
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= Unreleased =
+* Use helper function `pmos_get_settings`.
+
 = 1.1.4 =
 * Custom filter `ping_me_on_slack_dispatcher` for global Slack client.
 * Feat: New Password control in Form options.

--- a/tests/Core/ClientTest.php
+++ b/tests/Core/ClientTest.php
@@ -29,7 +29,7 @@ class ClientTest extends TestCase {
 		$client->shouldAllowMockingProtectedMethods();
 
 		\WP_Mock::userFunction( 'get_option' )
-			->once()
+			->times( 3 )
 			->with( 'ping_me_on_slack', [] )
 			->andReturn(
 				[

--- a/tests/Core/ClientTest.php
+++ b/tests/Core/ClientTest.php
@@ -10,6 +10,7 @@ use Maknz\Slack\Client as SlackClient;
 /**
  * @covers \PingMeOnSlack\Core\Client::ping
  * @covers \PingMeOnSlack\Core\Client::get_slack_client
+ * @covers pmos_get_settings
  */
 class ClientTest extends TestCase {
 	public Client $client;


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ping-me-on-slack/issues/9).

## Description / Background Context

At the moment we are using the WP get_option function in the [Slack client class](https://github.com/badasswp/ping-me-on-slack/blob/65836d7b511c4098dd3a5c4e00b254fcb50bdb30/inc/Core/Client.php#L25-L33) to retrieve the plugin options.

This PR refactors this logic to use the `pmos_get_settings` helper function.

## Testing Instructions

1. Pull PR to local.
2. All features should work correctly as before.
3. All tests should pass as before when you run: `composer run test`.