### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1
+* Bump up plugin version.
+* Tested up to WP 6.8
+* Update README docs.
+
 ## 1.2.0
 * Fix custom filters, ensure `args` is correctly set for Slack `client`.
 * Feat: Add `.wp-env` config for dev env.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ping-me-on-slack",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Get notifications on Slack when changes are made on your WP website.",
 	"author": "badasswp",
 	"license": "GPL-3.0-or-later",

--- a/ping-me-on-slack.php
+++ b/ping-me-on-slack.php
@@ -3,7 +3,7 @@
  * Plugin Name: Ping Me On Slack
  * Plugin URI:  https://github.com/badasswp/ping-me-on-slack
  * Description: Get notifications on Slack when changes are made on your WP website.
- * Version:     1.2.0
+ * Version:     1.2.1
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: badasswp
 Tags: slack, ping, notify, chat.
 Requires at least: 4.0
-Tested up to: 6.7.2
-Stable tag: 1.2.0
+Tested up to: 6.8
+Stable tag: 1.2.1
 Requires PHP: 8.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,11 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.2.1 =
+* Bump up plugin version.
+* Tested up to WP 6.8
+* Update README docs.
+
 = 1.2.0 =
 * Fix custom filters, ensure `args` is correctly set for Slack `client`.
 * Feat: Add `.wp-env` config for dev env.


### PR DESCRIPTION
This release does not contain any functional change:

* Bump up plugin version.
* Tested up to WP 6.8
* Update README docs.