### PR TITLE
Feat: Add more plugins options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0
 * Refactor: Replaced fully qualified path classes with their `use` counter part.
 * Feat: Added language translations for Japanese, Indonesia, Turkish, Polish, Dutch, Brazil, Portuguese.
+* Feat: Add `More Plugins` options page.
 
 ## 1.3.0
 * Chore: Update CI/CD pipeline.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     }
   ],
   "require": {
-    "alek13/slack": "^2.1"
+    "alek13/slack": "^2.1",
+    "badasswp/pluginate": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6",

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -12,7 +12,27 @@ use PingMeOnSlack\Admin\Options;
 use PingMeOnSlack\Abstracts\Service;
 use PingMeOnSlack\Interfaces\Kernel;
 
+use Pluginate\Admin as Pluginate;
+
 class Admin extends Service implements Kernel {
+	/**
+	 * Pluginate instance.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var Pluginate
+	 */
+	public Pluginate $pluginate;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @since 1.4.0
+	 */
+	public function __construct() {
+		$this->pluginate = new Pluginate( 'ping-me-on-slack' );
+	}
+
 	/**
 	 * Bind to WP.
 	 *
@@ -24,6 +44,7 @@ class Admin extends Service implements Kernel {
 		add_action( 'admin_init', [ $this, 'register_options_init' ] );
 		add_action( 'admin_menu', [ $this, 'register_options_menu' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_options_styles' ] );
+		add_action( 'admin_init', [ $this->pluginate, 'init' ] );
 	}
 
 	/**
@@ -44,6 +65,15 @@ class Admin extends Service implements Kernel {
 			[ $this, 'register_options_page' ],
 			'dashicons-format-chat',
 			100
+		);
+
+		add_submenu_page(
+			Options::get_page_slug(),
+			__( 'More Plugins', 'ping-me-on-slack' ),
+			__( 'More Plugins', 'ping-me-on-slack' ),
+			'manage_options',
+			sprintf( '%s-more-plugins', Options::get_page_slug() ),
+			[ $this, 'register_more_plugins' ]
 		);
 	}
 
@@ -67,6 +97,35 @@ class Admin extends Service implements Kernel {
 			array_map(
 				'__',
 				( new Form( Options::$form ) )->get_options()
+			)
+		);
+	}
+
+	/**
+	 * Register More Plugins.
+	 *
+	 * This controls the display of the
+	 * "More Plugins" submenu page.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return void
+	 */
+	public function register_more_plugins(): void {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		vprintf(
+			'<section class="wrap">
+				<h1>%s</h1>
+				<p>%s</p>
+				%s
+			</section>',
+			array_map(
+				'__',
+				[
+					'More Plugins',
+					'Check out some other amazing plugin of ours...',
+					$this->pluginate->get_more_plugins(),
+				]
 			)
 		);
 	}
@@ -129,7 +188,7 @@ class Admin extends Service implements Kernel {
 		$screen = get_current_screen();
 
 		// Bail out, if not plugin Admin page.
-		if ( ! is_object( $screen ) || 'toplevel_page_ping-me-on-slack' !== $screen->id ) {
+		if ( ! is_object( $screen ) || ! str_contains( $screen->id, Options::get_page_slug() ) ) {
 			return;
 		}
 

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -27,6 +27,7 @@ use PingMeOnSlack\Core\Container;
  * @covers \PingMeOnSlack\Services\Post::register
  * @covers \PingMeOnSlack\Services\Theme::register
  * @covers \PingMeOnSlack\Services\User::register
+ * @covers \PingMeOnSlack\Services\Admin::__construct
  */
 class ContainerTest extends TestCase {
 	public Container $container;

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -113,6 +113,16 @@ class ContainerTest extends TestCase {
 			]
 		);
 
+		$admin = Service::$services[ Admin::class ];
+
+		WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				$admin->pluginate,
+				'init',
+			]
+		);
+
 		WP_Mock::expectActionAdded(
 			'transition_comment_status',
 			[

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -29,6 +29,7 @@ use PingMeOnSlack\Services\Comment;
  * @covers \PingMeOnSlack\Services\Post::register
  * @covers \PingMeOnSlack\Services\Theme::register
  * @covers \PingMeOnSlack\Services\User::register
+ * @covers \PingMeOnSlack\Services\Admin::__construct
  */
 class PluginTest extends TestCase {
 	public array $services;
@@ -107,6 +108,16 @@ class PluginTest extends TestCase {
 			[
 				Service::$services['PingMeOnSlack\Services\Admin'],
 				'register_options_styles',
+			]
+		);
+
+		$admin = Service::$services['PingMeOnSlack\Services\Admin'];
+
+		WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				$admin->pluginate,
+				'init',
 			]
 		);
 

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -91,7 +91,7 @@ class AdminTest extends TestCase {
 			->andReturn( null );
 
 		WP_Mock::userFunction( '__' )
-			->andReturnArg( 0 );
+			->andReturnUsing( fn( $text, $domain ) => $text );
 
 		WP_Mock::userFunction( 'add_submenu_page' )
 			->once()

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -90,7 +90,7 @@ class AdminTest extends TestCase {
 			->andReturn( null );
 
 		WP_Mock::userFunction( '__' )
-    		->andReturnArg( 0 );
+			->andReturnArg( 0 );
 
 		WP_Mock::userFunction( 'add_submenu_page' )
 			->once()

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -41,6 +41,7 @@ class AdminTest extends TestCase {
 		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
 		WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
 		WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
+		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin->pluginate, 'init' ] );
 
 		$this->admin->register();
 
@@ -87,6 +88,19 @@ class AdminTest extends TestCase {
 				100
 			)
 			->andReturn( null );
+
+		WP_Mock::userFunction( 'add_submenu_page' )
+			->once()
+			->with(
+				'ping-me-on-slack',
+				__( 'More Plugins', 'ping-me-on-slack' ),
+				__( 'More Plugins', 'ping-me-on-slack' ),
+				'manage_options',
+				sprintf( '%s-more-plugins', 'ping-me-on-slack' ),
+				[ $this->admin, 'register_more_plugins' ]
+			)
+			->andReturn( null );
+
 
 		$menu = $this->admin->register_options_menu();
 

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -97,10 +97,10 @@ class AdminTest extends TestCase {
 			->once()
 			->with(
 				'ping-me-on-slack',
-				__( 'More Plugins', 'ping-me-on-slack' ),
-				__( 'More Plugins', 'ping-me-on-slack' ),
+				'More Plugins',
+				'More Plugins',
 				'manage_options',
-				sprintf( '%s-more-plugins', 'ping-me-on-slack' ),
+				'ping-me-on-slack-more-plugins',
 				[ $this->admin, 'register_more_plugins' ]
 			)
 			->andReturn( null );

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -19,6 +19,7 @@ use PingMeOnSlack\Services\Admin;
  * @covers \PingMeOnSlack\Admin\Options::get_form_page
  * @covers \PingMeOnSlack\Admin\Options::get_form_submit
  * @covers \PingMeOnSlack\Admin\Options::init
+ * @covers \PingMeOnSlack\Services\Admin::__construct
  */
 class AdminTest extends TestCase {
 	public Admin $admin;

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -101,7 +101,6 @@ class AdminTest extends TestCase {
 			)
 			->andReturn( null );
 
-
 		$menu = $this->admin->register_options_menu();
 
 		$this->assertNull( $menu );

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -89,6 +89,9 @@ class AdminTest extends TestCase {
 			)
 			->andReturn( null );
 
+		WP_Mock::userFunction( '__' )
+    		->andReturnArg( 0 );
+
 		WP_Mock::userFunction( 'add_submenu_page' )
 			->once()
 			->with(


### PR DESCRIPTION
This PR resolves [WP-194](https://appworld.atlassian.net/browse/WP-194)

## Description / Background Context

This PR introduces a new More Plugins options page via the Pluginate repo.

## Testing Instructions

- Pull PR to local.
- Run `composer update` to pull in the `Pluginate` package.
- Proceed to the **More Plugins** page under the **Ping Me On Slack** menu.
- Observe that everything still works correctly as expected and you can install and activate a plugin from same.

## Screenshots / Screencast

<img width="119" height="77" alt="Screenshot 2026-06-08 103515" src="https://github.com/user-attachments/assets/ee56979b-d516-4067-819e-007aba6e4653" />

---

<img width="948" height="436" alt="Screenshot 2026-06-08 103534" src="https://github.com/user-attachments/assets/1f8724f1-6446-422f-9a50-4f25f5823a8e" />


---


<img width="812" height="205" alt="Screenshot 2026-06-08 103617" src="https://github.com/user-attachments/assets/eab32e5a-9c4e-4fd4-b1b6-7567dfc09ef2" />
